### PR TITLE
README: add reference to os.ExpandEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ func main() {
 |`${var:+$OTHER}`   | If var set, evaluate expression as $OTHER, otherwise as empty string
 <sub>table taken from [here](http://www.tldp.org/LDP/abs/html/refcards.html#AEN22728)</sub>
 
+### See also
+
+* `os.ExpandEnv(s string) string` - only supports `$var` and `${var}` notations
 
 #### License
 MIT


### PR DESCRIPTION
I think it's useful to guide visitors, if they just need the basic env substitution then there is one facility in the stdlib.