### PR TITLE
support for restriction flags -no-unset and -no-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ $ echo 'welcome $HOME ${USER:=a8m}' | envsubst
 $ envsubst -help
 ```
 
+#### Imposing restrictions
+There are two command line flags with which you can cause the substitution to stop with an error code, should the restriction associated with the flag not be met. This can be handy if you want to avoid creating e.g. configuration files with unset or empty parameters. The flags and their restrictions are: 
+
+|__Flag__     | __Meaning__    |
+| ------------| -------------- |
+|`-no-unset`  | fail if a variable is not set
+|`-no-empty`  | fail if a variable is set but empty
+
+These flags can be combined to form tighter restrictions. 
+
 #### Using `envsubst` programmatically ?
 You can take a look on [`_example/main`](https://github.com/a8m/envsubst/blob/master/_example/main.go) or see the example below.
 ```go

--- a/cmd/envsubst/main.go
+++ b/cmd/envsubst/main.go
@@ -12,15 +12,19 @@ import (
 )
 
 var (
-	input  = flag.String("i", "", "")
-	output = flag.String("o", "", "")
+	input   = flag.String("i", "", "")
+	output  = flag.String("o", "", "")
+	noUnset = flag.Bool("no-unset", false, "")
+	noEmpty = flag.Bool("no-empty", false, "")
 )
 
 var usage = `Usage: envsubst [options...] <input>
 Options:
-  -i  Specify file input, otherwise use last argument as input file. 
-      If no input file is specified, read from stdin.
-  -o  Specify file output. If none is specified, write to stdout.
+  -i         Specify file input, otherwise use last argument as input file. 
+             If no input file is specified, read from stdin.
+  -o         Specify file output. If none is specified, write to stdout.
+  -no-unset  Fail if a variable is not set.
+  -no-empty  Fail if a variable is set but empty.
 `
 
 func main() {
@@ -68,9 +72,9 @@ func main() {
 		file = os.Stdout
 	}
 	// Parse input string
-	result, err := envsubst.String(data)
+	result, err := envsubst.StringRestricted(data, *noUnset, *noEmpty)
 	if err != nil {
-		usageAndExit(fmt.Sprintf("envsubst error: %s.", err))
+		errorAndExit(err)
 	}
 	if _, err := file.WriteString(result); err != nil {
 		filename := *output
@@ -88,5 +92,10 @@ func usageAndExit(msg string) {
 	}
 	flag.Usage()
 	fmt.Fprintf(os.Stderr, "\n")
+	os.Exit(1)
+}
+
+func errorAndExit(e error) {
+	fmt.Fprintf(os.Stderr, "%v\n\n", e.Error())
 	os.Exit(1)
 }

--- a/envsubst.go
+++ b/envsubst.go
@@ -10,13 +10,27 @@ import (
 // String returns the parsed template string after processing it.
 // If the parser encounters invalid input, it returns an error describing the failure.
 func String(s string) (string, error) {
-	return parse.New("string", os.Environ()).Parse(s)
+	return StringRestricted(s, false, false)
+}
+
+// String returns the parsed template string after processing it.
+// If the parser encounters invalid input, or a restriction is violated, it returns
+// an error describing the failure.
+func StringRestricted(s string, noUnset, noEmpty bool) (string, error) {
+	return parse.New("string", os.Environ(), noUnset, noEmpty).Parse(s)
 }
 
 // Bytes returns the bytes represented by the parsed template after processing it.
 // If the parser encounters invalid input, it returns an error describing the failure.
 func Bytes(b []byte) ([]byte, error) {
-	s, err := parse.New("bytes", os.Environ()).Parse(string(b))
+	return BytesRestricted(b, false, false)
+}
+
+// Bytes returns the bytes represented by the parsed template after processing it.
+// If the parser encounters invalid input, or a restriction is violated, it returns
+// an error describing the failure.
+func BytesRestricted(b []byte, noUnset, noEmpty bool) ([]byte, error) {
+	s, err := parse.New("bytes", os.Environ(), noUnset, noEmpty).Parse(string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -27,9 +41,16 @@ func Bytes(b []byte) ([]byte, error) {
 // If the call to io.ReadFile failed it returns the error; otherwise it will
 // call envsubst.Bytes with the returned content.
 func ReadFile(filename string) ([]byte, error) {
+	return ReadFileRestricted(filename, false, false)
+}
+
+// ReadFile call io.ReadFile with the given file name.
+// If the call to io.ReadFile failed it returns the error; otherwise it will
+// call envsubst.Bytes with the returned content.
+func ReadFileRestricted(filename string, noUnset, noEmpty bool) ([]byte, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return Bytes(b)
+	return BytesRestricted(b, noUnset, noEmpty)
 }

--- a/envsubst.go
+++ b/envsubst.go
@@ -13,11 +13,12 @@ func String(s string) (string, error) {
 	return StringRestricted(s, false, false)
 }
 
-// String returns the parsed template string after processing it.
+// StringRestricted returns the parsed template string after processing it.
 // If the parser encounters invalid input, or a restriction is violated, it returns
 // an error describing the failure.
 func StringRestricted(s string, noUnset, noEmpty bool) (string, error) {
-	return parse.New("string", os.Environ(), noUnset, noEmpty).Parse(s)
+	return parse.New("string", os.Environ(),
+		&parse.Restrictions{noUnset, noEmpty}).Parse(s)
 }
 
 // Bytes returns the bytes represented by the parsed template after processing it.
@@ -26,11 +27,12 @@ func Bytes(b []byte) ([]byte, error) {
 	return BytesRestricted(b, false, false)
 }
 
-// Bytes returns the bytes represented by the parsed template after processing it.
+// BytesRestricted returns the bytes represented by the parsed template after processing it.
 // If the parser encounters invalid input, or a restriction is violated, it returns
 // an error describing the failure.
 func BytesRestricted(b []byte, noUnset, noEmpty bool) ([]byte, error) {
-	s, err := parse.New("bytes", os.Environ(), noUnset, noEmpty).Parse(string(b))
+	s, err := parse.New("bytes", os.Environ(),
+		&parse.Restrictions{noUnset, noEmpty}).Parse(string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +46,7 @@ func ReadFile(filename string) ([]byte, error) {
 	return ReadFileRestricted(filename, false, false)
 }
 
-// ReadFile call io.ReadFile with the given file name.
+// ReadFileRestricted calls io.ReadFile with the given file name.
 // If the call to io.ReadFile failed it returns the error; otherwise it will
 // call envsubst.Bytes with the returned content.
 func ReadFileRestricted(filename string, noUnset, noEmpty bool) ([]byte, error) {

--- a/parse/node.go
+++ b/parse/node.go
@@ -1,7 +1,6 @@
 package parse
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -95,7 +94,7 @@ func (t *SubstitutionNode) validate(node Node) (string, error) {
 
 func (t *SubstitutionNode) validateNoUnset(node Node) error {
 	if t.Restrict.NoUnset && node.Type() == NodeVariable && !node.(*VariableNode).isSet() {
-		return errors.New(fmt.Sprintf("variable ${%s} not set", t.Variable.Ident))
+		return fmt.Errorf("variable ${%s} not set", t.Variable.Ident)
 	}
 	return nil
 }
@@ -103,7 +102,7 @@ func (t *SubstitutionNode) validateNoUnset(node Node) error {
 func (t *SubstitutionNode) validateNoEmpty(node Node) (string, error) {
 	value, _ := node.String()
 	if t.Restrict.NoEmpty && value == "" && (node.Type() != NodeVariable || node.(*VariableNode).isSet()) {
-		return "", errors.New(fmt.Sprintf("variable ${%s} set but empty", t.Variable.Ident))
+		return "", fmt.Errorf("variable ${%s} set but empty", t.Variable.Ident)
 	}
 	return value, nil
 }

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -28,11 +28,7 @@ type Parser struct {
 }
 
 // New allocates a new Parser with the given name.
-func New(name string, env []string, noUnset, noEmpty bool) *Parser {
-	return newRestricted(name, env, &Restrictions{noUnset, noEmpty})
-}
-
-func newRestricted(name string, env []string, r *Restrictions) *Parser {
+func New(name string, env []string, r *Restrictions) *Parser {
 	return &Parser{
 		Name:     name,
 		Env:      Env(env),

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -8,47 +8,119 @@ var FakeEnv = []string{
 	"BAR=bar",
 	"FOO=foo",
 	"EMPTY=",
+	"ALSO_EMPTY=",
 }
+
+type mode int
+
+const (
+	relaxed mode = iota
+	noUnset
+	noEmpty
+	strict
+)
+
+var restrict = map[mode]*Restrictions{
+	relaxed: Relaxed,
+	noUnset: NoUnset,
+	noEmpty: NoEmpty,
+	strict:  Strict,
+}
+
+var errNone = map[mode]bool{}
+var errUnset = map[mode]bool{noUnset: true, strict: true}
+var errEmpty = map[mode]bool{noEmpty: true, strict: true}
+var errAll = map[mode]bool{relaxed: true, noUnset: true, noEmpty: true, strict: true}
 
 type parseTest struct {
 	name     string
 	input    string
 	expected string
-	hasErr   bool
+	hasErr   map[mode]bool
 }
 
 var parseTests = []parseTest{
-	{"empty", "", "", false},
-	{"env only", "$BAR", "bar", false},
-	{"with text", "$BAR baz", "bar baz", false},
-	{"concatenated", "$BAR$FOO", "barfoo", false},
-	{"2 env var", "$BAR - $FOO", "bar - foo", false},
-	{"invalid var", "$_ bar", "$_ bar", false},
-	{"invalid subst var", "${_} bar", "${_} bar", false},
-	{"value of $var", "${BAR}baz", "barbaz", false},
-	{"$var not set -", "${NOTSET-$BAR}", "bar", false},
-	{"$var not set =", "${NOTSET=$BAR}", "bar", false},
-	{"$var set but empty -", "${EMPTY-$BAR}", "", false},
-	{"$var set but empty =", "${EMPTY=$BAR}", "", false},
-	{"$var not set or empty :-", "${EMPTY:-$BAR}", "bar", false},
-	{"$var not set or empty :=", "${EMPTY:=$BAR}", "bar", false},
-	{"if $var set evaluate expression as $other +", "${EMPTY+hello}", "hello", false},
-	{"if $var set evaluate expression as $other :+", "${EMPTY:+hello}", "hello", false},
-	{"if $var not set, use empty string +", "${NOTSET+hello}", "", false},
-	{"if $var not set, use empty string :+", "${NOTSET:+hello}", "", false},
-	{"multi line string", "hello $BAR\nhello ${EMPTY:=$FOO}", "hello bar\nhello foo", false},
-	{"issue #1", "${hello:=wo_rld} ${foo:=bar_baz}", "wo_rld bar_baz", false},
-	{"issue #2", "name: ${NAME:=foo_qux}, key: ${EMPTY:=baz_bar}", "name: foo_qux, key: baz_bar", false},
+	{"empty", "", "", errNone},
+	{"env only", "$BAR", "bar", errNone},
+	{"with text", "$BAR baz", "bar baz", errNone},
+	{"concatenated", "$BAR$FOO", "barfoo", errNone},
+	{"2 env var", "$BAR - $FOO", "bar - foo", errNone},
+	{"invalid var", "$_ bar", "$_ bar", errNone},
+	{"invalid subst var", "${_} bar", "${_} bar", errNone},
+	{"value of $var", "${BAR}baz", "barbaz", errNone},
+	{"$var not set -", "${NOTSET-$BAR}", "bar", errNone},
+	{"$var not set =", "${NOTSET=$BAR}", "bar", errNone},
+	{"$var set but empty -", "${EMPTY-$BAR}", "", errEmpty},
+	{"$var set but empty =", "${EMPTY=$BAR}", "", errEmpty},
+	{"$var not set or empty :-", "${EMPTY:-$BAR}", "bar", errNone},
+	{"$var not set or empty :=", "${EMPTY:=$BAR}", "bar", errNone},
+	{"if $var set evaluate expression as $other +", "${EMPTY+hello}", "hello", errNone},
+	{"if $var set evaluate expression as $other :+", "${EMPTY:+hello}", "hello", errNone},
+	{"if $var not set, use empty string +", "${NOTSET+hello}", "", errNone},
+	{"if $var not set, use empty string :+", "${NOTSET:+hello}", "", errNone},
+	{"multi line string", "hello $BAR\nhello ${EMPTY:=$FOO}", "hello bar\nhello foo", errNone},
+	{"issue #1", "${hello:=wo_rld} ${foo:=bar_baz}", "wo_rld bar_baz", errNone},
+	{"issue #2", "name: ${NAME:=foo_qux}, key: ${EMPTY:=baz_bar}", "name: foo_qux, key: baz_bar", errNone},
 	// bad substitution
-	{"closing brace expected", "hello ${", "", true},
+	{"closing brace expected", "hello ${", "", errAll},
+
+	// test specifically for failure modes
+	{"$var not set", "${NOTSET}", "", errUnset},
+	{"$var set to empty", "${EMPTY}", "", errEmpty},
+
+	{"$var and $DEFAULT not set -", "${NOTSET-$ALSO_NOTSET}", "", errUnset},
+	{"$var and $DEFAULT not set :-", "${NOTSET:-$ALSO_NOTSET}", "", errUnset},
+	{"$var and $DEFAULT not set =", "${NOTSET=$ALSO_NOTSET}", "", errUnset},
+	{"$var and $DEFAULT not set :=", "${NOTSET:=$ALSO_NOTSET}", "", errUnset},
+	{"$var and $OTHER not set +", "${NOTSET+$ALSO_NOTSET}", "", errNone},
+	{"$var and $OTHER not set :+", "${NOTSET:+$ALSO_NOTSET}", "", errNone},
+
+	{"$var empty and $DEFAULT not set -", "${EMPTY-$NOTSET}", "", errEmpty},
+	{"$var empty and $DEFAULT not set :-", "${EMPTY:-$NOTSET}", "", errUnset},
+	{"$var empty and $DEFAULT not set =", "${EMPTY=$NOTSET}", "", errEmpty},
+	{"$var empty and $DEFAULT not set :=", "${EMPTY:=$NOTSET}", "", errUnset},
+	{"$var empty and $OTHER not set +", "${EMPTY+$NOTSET}", "", errUnset},
+	{"$var empty and $OTHER not set :+", "${EMPTY:+$NOTSET}", "", errUnset},
+
+	{"$var not set and $DEFAULT empty -", "${NOTSET-$EMPTY}", "", errEmpty},
+	{"$var not set and $DEFAULT empty :-", "${NOTSET:-$EMPTY}", "", errEmpty},
+	{"$var not set and $DEFAULT empty =", "${NOTSET=$EMPTY}", "", errEmpty},
+	{"$var not set and $DEFAULT empty :=", "${NOTSET:=$EMPTY}", "", errEmpty},
+	{"$var not set and $OTHER empty +", "${NOTSET+$EMPTY}", "", errNone},
+	{"$var not set and $OTHER empty :+", "${NOTSET:+$EMPTY}", "", errNone},
+
+	{"$var and $DEFAULT empty -", "${EMPTY-$ALSO_EMPTY}", "", errEmpty},
+	{"$var and $DEFAULT empty :-", "${EMPTY:-$ALSO_EMPTY}", "", errEmpty},
+	{"$var and $DEFAULT empty =", "${EMPTY=$ALSO_EMPTY}", "", errEmpty},
+	{"$var and $DEFAULT empty :=", "${EMPTY:=$ALSO_EMPTY}", "", errEmpty},
+	{"$var and $OTHER empty +", "${EMPTY+$ALSO_EMPTY}", "", errEmpty},
+	{"$var and $OTHER empty :+", "${EMPTY:+$ALSO_EMPTY}", "", errEmpty},
+	//
 }
 
 func TestParse(t *testing.T) {
+	doTest(t, relaxed)
+}
+
+func TestParseNoUnset(t *testing.T) {
+	doTest(t, noUnset)
+}
+
+func TestParseNoEmpty(t *testing.T) {
+	doTest(t, noEmpty)
+}
+
+func TestParseStrict(t *testing.T) {
+	doTest(t, strict)
+}
+
+func doTest(t *testing.T, m mode) {
 	for _, test := range parseTests {
-		result, err := New(test.name, FakeEnv).Parse(test.input)
+		result, err := newRestricted(test.name, FakeEnv, restrict[m]).Parse(test.input)
 		hasErr := err != nil
-		if hasErr != test.hasErr {
-			t.Errorf("%s=(error): got\n\t%v\nexpected\n\t%v", test.name, hasErr, test.hasErr)
+		if hasErr != test.hasErr[m] {
+			t.Errorf("%s=(error): got\n\t%v\nexpected\n\t%v\ninput: %s\nresult: %s\nerror: %v",
+				test.name, hasErr, test.hasErr[m], test.input, result, err)
 		}
 		if result != test.expected {
 			t.Errorf("%s=(%q): got\n\t%v\nexpected\n\t%v", test.name, test.input, result, test.expected)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -116,7 +116,7 @@ func TestParseStrict(t *testing.T) {
 
 func doTest(t *testing.T, m mode) {
 	for _, test := range parseTests {
-		result, err := newRestricted(test.name, FakeEnv, restrict[m]).Parse(test.input)
+		result, err := New(test.name, FakeEnv, restrict[m]).Parse(test.input)
 		hasErr := err != nil
 		if hasErr != test.hasErr[m] {
 			t.Errorf("%s=(error): got\n\t%v\nexpected\n\t%v\ninput: %s\nresult: %s\nerror: %v",


### PR DESCRIPTION
I added two flags `-no-unset` and `-no-empty` to the `envsubst` command, with which you can cause the substitution to stop with an error code, should the restriction associated with the flag not be met. This can be handy if you want to avoid creating e.g. configuration files with unset or empty parameters. The flags and their restrictions are:

|__Flag__     | __Meaning__    |
| ------------| -------------- |
|`-no-unset`  | fail if a variable is not set
|`-no-empty`  | fail if a variable is set but empty

These flags can be combined to form tighter restrictions. 

Sorry about the fairly large change set...