### PR TITLE
[issue #9] moving restriction validation to VariableNode fixes issue

### DIFF
--- a/parse/node.go
+++ b/parse/node.go
@@ -77,7 +77,6 @@ func (t *VariableNode) validateNoEmpty(value string) error {
 	return nil
 }
 
-//
 type SubstitutionNode struct {
 	NodeType
 	ExpType  itemType

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -67,7 +67,7 @@ Loop:
 		case itemError:
 			return p.errorf(t.val)
 		case itemVariable:
-			varNode := NewVariable(strings.TrimPrefix(t.val, "$"), p.Env)
+			varNode := NewVariable(strings.TrimPrefix(t.val, "$"), p.Env, p.Restrict)
 			p.nodes = append(p.nodes, varNode)
 		case itemLeftDelim:
 			if p.peek().typ == itemVariable {
@@ -91,7 +91,7 @@ Loop:
 func (p *Parser) action() (Node, error) {
 	var expType itemType
 	var defaultNode Node
-	varNode := NewVariable(p.next().val, p.Env)
+	varNode := NewVariable(p.next().val, p.Env, p.Restrict)
 Loop:
 	for {
 		switch t := p.next(); t.typ {
@@ -100,7 +100,7 @@ Loop:
 		case itemError:
 			return nil, p.errorf(t.val)
 		case itemVariable:
-			defaultNode = NewVariable(strings.TrimPrefix(t.val, "$"), p.Env)
+			defaultNode = NewVariable(strings.TrimPrefix(t.val, "$"), p.Env, p.Restrict)
 		case itemText:
 			n := NewText(t.val)
 		Text:
@@ -118,7 +118,7 @@ Loop:
 			expType = t.typ
 		}
 	}
-	return &SubstitutionNode{NodeSubstitution, expType, varNode, defaultNode, p.Restrict}, nil
+	return &SubstitutionNode{NodeSubstitution, expType, varNode, defaultNode}, nil
 }
 
 func (p *Parser) errorf(s string) error {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -68,6 +68,9 @@ var parseTests = []parseTest{
 	// test specifically for failure modes
 	{"$var not set", "${NOTSET}", "", errUnset},
 	{"$var set to empty", "${EMPTY}", "", errEmpty},
+	// restrictions for plain variables without braces
+	{"gh-issue-9", "$NOTSET", "", errUnset},
+	{"gh-issue-9", "$EMPTY", "", errEmpty},
 
 	{"$var and $DEFAULT not set -", "${NOTSET-$ALSO_NOTSET}", "", errUnset},
 	{"$var and $DEFAULT not set :-", "${NOTSET:-$ALSO_NOTSET}", "", errUnset},


### PR DESCRIPTION
Realized that restriction validation belongs to `VariableNode`, not `SubstitutionNode`. Moving it there fixes the issue.