### PR TITLE
convert Env to an interface and implement a Functor variant.

### DIFF
--- a/cmd/envsubst/main.go
+++ b/cmd/envsubst/main.go
@@ -80,7 +80,7 @@ func main() {
 		parserMode = parse.Quick
 	}
 	restrictions := &parse.Restrictions{*noUnset, *noEmpty}
-	result, err := (&parse.Parser{Name: "string", Env: os.Environ(), Restrict: restrictions, Mode: parserMode}).Parse(data)
+	result, err := (&parse.Parser{Name: "string", Env: parse.NewOsFunctorEnv(), Restrict: restrictions, Mode: parserMode}).Parse(data)
 	if err != nil {
 		errorAndExit(err)
 	}

--- a/parse/env.go
+++ b/parse/env.go
@@ -1,22 +1,99 @@
 package parse
 
 import (
+	"os"
 	"strings"
 )
 
-type Env []string
+type Env interface {
+	// Get fetches the value associated
+	// with the key or an empty string
+	// if nothing is found.
+	Get(name string) string
+	// Has checks if the given key is present
+	// in the datasource.
+	Has(name string) bool
+	// Lookup searches the datasource(s)
+	// for a possible match. Returns the
+	// value associated with the key and
+	// the status of the search.
+	Lookup(name string) (string, bool)
+}
 
-func (e Env) Get(name string) string {
+type FunctorEnv struct {
+	Mapping func(string) string
+}
+
+func NewFunctorEnv(mapping func(string) string) *FunctorEnv {
+	return &FunctorEnv {
+		Mapping: mapping,
+	}
+}
+
+// NewOsFunctorEnv will create a FunctorEnv
+// object using os.Getenv as datasource.
+func NewOsFunctorEnv() *FunctorEnv {
+	return &FunctorEnv {
+		Mapping: os.Getenv,
+	}
+}
+
+// Get is a wrapper around Lookup,
+// only returning the first return value.
+func (e *FunctorEnv) Get(name string) string {
 	v, _ := e.Lookup(name)
 	return v
 }
 
-func (e Env) Has(name string) bool {
+// Has is a wrapper around Lookup,
+// only returning the second return value.
+func (e *FunctorEnv) Has(name string) bool {
 	_, ok := e.Lookup(name)
 	return ok
 }
 
-func (e Env) Lookup(name string) (string, bool) {
+// Lookup returns the value associated with the provided key.
+// If the lookup yields an empty string, the behaviour
+// is the same as if the key does not exist in the first place:
+// the search fails.
+func (e *FunctorEnv) Lookup(name string) (string, bool) {
+	if value := e.Mapping(name); value != "" {
+		return value, true
+	}
+
+	return "", false
+}
+
+type SliceEnv []string
+
+func NewSliceEnv(source []string) SliceEnv {
+	return SliceEnv(source)
+}
+
+// NewOsSliceEnv will create a SliceEnv
+// object using os.Environ() as datasource.
+func NewOsSliceEnv() SliceEnv {
+	return SliceEnv(os.Environ())
+}
+
+// Get is a wrapper around Lookup,
+// only returning the first return value.
+func (e SliceEnv) Get(name string) string {
+	v, _ := e.Lookup(name)
+	return v
+}
+
+// Has is a wrapper around Lookup,
+// only returning the second return value.
+func (e SliceEnv) Has(name string) bool {
+	_, ok := e.Lookup(name)
+	return ok
+}
+
+// Lookup will iterate over the date source,
+// looking for elements with the given key
+// and an equal sign (=) as prefix.
+func (e SliceEnv) Lookup(name string) (string, bool) {
 	prefix := name + "="
 	for _, pair := range e {
 		if strings.HasPrefix(pair, prefix) {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -46,7 +46,7 @@ type Parser struct {
 func New(name string, env []string, r *Restrictions) *Parser {
 	return &Parser{
 		Name:     name,
-		Env:      Env(env),
+		Env:      NewSliceEnv(env),
 		Restrict: r,
 	}
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -148,7 +148,7 @@ func doTest(t *testing.T, m mode) {
 
 func doNegativeAssertTest(t *testing.T, m mode) {
 	for _, test := range negativeParseTests {
-		result, err := (*&Parser{Name: test.name, Env: FakeEnv, Restrict: restrict[m], Mode: AllErrors}).Parse(test.input)
+		result, err := (*&Parser{Name: test.name, Env: SliceEnv(FakeEnv), Restrict: restrict[m], Mode: AllErrors}).Parse(test.input)
 		hasErr := err != nil
 		if hasErr != test.hasErr[m] {
 			t.Errorf("%s=(error): got\n\t%v\nexpected\n\t%v\ninput: %s\nresult: %s\nerror: %v",


### PR DESCRIPTION
when dealing with a large environment (i.e. lots of environment
variables), the slice based lookup becomes inperformant. os also
allows variable lookups based on keys, which the Functor
implementation uses for its core logic.