### PR TITLE
Feature for selected Environments vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The flags and their restrictions are:
 |`-o`  | output file | ```string | stdout``` |  `stdout` 
 |`-no-unset`  | fail if a variable is not set | `flag` |  `false` 
 |`-no-empty`  | fail if a variable is set but empty | `flag` | `false`
+|`-envs`  | A comma-separated list of selected environment vars for substitution | `flag` | ``
 |`-fail-fast`  | fails at first occurence of an error, if `-no-empty` or `-no-unset` flags were **not** specified this is ignored | `flag` | `false`
 
 These flags can be combined to form tighter restrictions. 

--- a/envsubst.go
+++ b/envsubst.go
@@ -10,7 +10,14 @@ import (
 // String returns the parsed template string after processing it.
 // If the parser encounters invalid input, it returns an error describing the failure.
 func String(s string) (string, error) {
-	return StringRestricted(s, false, false)
+	return stringRestricted(s, false, false, nil)
+}
+
+// StringSelectedEnvs returns the parsed template string for only the selected Envs
+// specified by the caller after processing it.
+// If the parser encounters invalid input, it returns an error describing the failure.
+func StringSelectedEnvs(s string, selectedEnvs []string) (string, error) {
+	return stringRestricted(s, false, false, selectedEnvs)
 }
 
 // StringRestricted returns the parsed template string after processing it.
@@ -18,22 +25,54 @@ func String(s string) (string, error) {
 // an error describing the failure.
 // Errors on first failure or returns a collection of failures if failOnFirst is false
 func StringRestricted(s string, noUnset, noEmpty bool) (string, error) {
+	return stringRestricted(s, noUnset, noEmpty, nil)
+}
+
+// StringRestrictedSelectedEnvs returns the parsed template string for only the selected Envs
+// specified by the caller after processing it.
+// If the parser encounters invalid input, or a restriction is violated, it returns
+// an error describing the failure.
+// Errors on first failure or returns a collection of failures if failOnFirst is false
+func StringRestrictedSelectedEnvs(s string, noUnset, noEmpty bool, selectedEnvs []string) (string, error) {
+	return stringRestricted(s, noUnset, noEmpty, selectedEnvs)
+}
+
+func stringRestricted(s string, noUnset, noEmpty bool, selectedEnvs []string) (string, error) {
 	return parse.New("string", os.Environ(),
-		&parse.Restrictions{noUnset, noEmpty}).Parse(s)
+		&parse.Restrictions{NoUnset: noUnset, NoEmpty: noEmpty}, selectedEnvs).Parse(s)
 }
 
 // Bytes returns the bytes represented by the parsed template after processing it.
 // If the parser encounters invalid input, it returns an error describing the failure.
 func Bytes(b []byte) ([]byte, error) {
-	return BytesRestricted(b, false, false)
+	return bytesRestricted(b, false, false, nil)
+}
+
+// BytesSelectedEnvs returns the bytes represented by the parsed template for only the selected Envs
+// specified by the caller after processing it.
+// If the parser encounters invalid input, it returns an error describing the failure.
+func BytesSelectedEnvs(b []byte, selectedEnvs []string) ([]byte, error) {
+	return bytesRestricted(b, false, false, selectedEnvs)
 }
 
 // BytesRestricted returns the bytes represented by the parsed template after processing it.
 // If the parser encounters invalid input, or a restriction is violated, it returns
 // an error describing the failure.
 func BytesRestricted(b []byte, noUnset, noEmpty bool) ([]byte, error) {
+	return bytesRestricted(b, noUnset, noEmpty, nil)
+}
+
+// BytesRestrictedSelectedEnvs returns the bytes represented by the parsed template for
+// only the selected Envs specified by the caller after processing it.
+// If the parser encounters invalid input, or a restriction is violated, it returns
+// an error describing the failure.
+func BytesRestrictedSelectedEnvs(b []byte, noUnset, noEmpty bool, selectedEnvs []string) ([]byte, error) {
+	return bytesRestricted(b, noUnset, noEmpty, selectedEnvs)
+}
+
+func bytesRestricted(b []byte, noUnset, noEmpty bool, selectedEnvs []string) ([]byte, error) {
 	s, err := parse.New("bytes", os.Environ(),
-		&parse.Restrictions{noUnset, noEmpty}).Parse(string(b))
+		&parse.Restrictions{NoUnset: noUnset, NoEmpty: noEmpty}, selectedEnvs).Parse(string(b))
 	if err != nil {
 		return nil, err
 	}
@@ -44,16 +83,40 @@ func BytesRestricted(b []byte, noUnset, noEmpty bool) ([]byte, error) {
 // If the call to io.ReadFile failed it returns the error; otherwise it will
 // call envsubst.Bytes with the returned content.
 func ReadFile(filename string) ([]byte, error) {
-	return ReadFileRestricted(filename, false, false)
+	return readFileRestricted(filename, false, false, nil)
+}
+
+// ReadFileSelectedEnvs call io.ReadFile with the given file name.
+// If the call to io.ReadFile failed it returns the error; otherwise it will
+// call envsubst.Bytes with the returned content and selected Envs
+// specified by the caller.
+func ReadFileSelectedEnvs(filename string, selectedEnvs []string) ([]byte, error) {
+	return readFileRestricted(filename, false, false, selectedEnvs)
 }
 
 // ReadFileRestricted calls io.ReadFile with the given file name.
 // If the call to io.ReadFile failed it returns the error; otherwise it will
 // call envsubst.Bytes with the returned content.
 func ReadFileRestricted(filename string, noUnset, noEmpty bool) ([]byte, error) {
+	return readFileRestricted(filename, noUnset, noUnset, nil)
+}
+
+// ReadFileRestrictedSelectedEnvs calls io.ReadFile with the given file name.
+// If the call to io.ReadFile failed it returns the error; otherwise it will
+// call envsubst.Bytes with the returned content and selected Envs
+// specified by the caller.
+func ReadFileRestrictedSelectedEnvs(filename string, noUnset, noEmpty bool, selectedEnvs []string) ([]byte, error) {
+	return readFileRestricted(filename, noUnset, noUnset, selectedEnvs)
+}
+
+// ReadFileRestricted calls io.ReadFile with the given file name.
+// If the call to io.ReadFile failed it returns the error; otherwise it will
+// call envsubst.Bytes with the returned content and selected Envs
+// if specified by the caller.
+func readFileRestricted(filename string, noUnset, noEmpty bool, selectedEnvs []string) ([]byte, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return BytesRestricted(b, noUnset, noEmpty)
+	return bytesRestricted(b, noUnset, noEmpty, selectedEnvs)
 }

--- a/envsubst_test.go
+++ b/envsubst_test.go
@@ -15,16 +15,47 @@ func init() {
 func TestIntegration(t *testing.T) {
 	input, expected := "foo $BAR", "foo bar"
 	str, err := String(input)
+	if err != nil {
+		t.Error("String ran unsuccesfully")
+	}
 	if str != expected || err != nil {
-		t.Error("Expect string integration test to pass")
+		t.Error("Expect String integration test to pass")
+	}
+	strenv, err := StringSelectedEnvs(input, []string{"BAR"})
+	if err != nil {
+		t.Error("StringSelectedEnvs ran unsuccesfully")
+	}
+	if strenv != expected || err != nil {
+		t.Error("Expect StringSelectedEnvs integration test to pass")
 	}
 	bytes, err := Bytes([]byte(input))
+	if err != nil {
+		t.Error("Bytes ran unsuccesfully")
+	}
 	if string(bytes) != expected || err != nil {
 		t.Error("Expect bytes integration test to pass")
 	}
-	bytes, err = ReadFile("testdata/file.tmpl")
+	bytesenv, err := BytesSelectedEnvs([]byte(input), []string{"BAR"})
+	if err != nil {
+		t.Error("BytesSelectedEnvs ran unsuccesfully")
+	}
+	if string(bytesenv) != expected || err != nil {
+		t.Error("Expect BytesSelectedEnvs integration test to pass")
+	}
+	readfile, err := ReadFile("testdata/file.tmpl")
+	if err != nil {
+		t.Error("ReadFile ran unsuccesfully")
+	}
 	fexpected, err := ioutil.ReadFile("testdata/file.out")
-	if string(bytes) != string(fexpected) || err != nil {
+	if string(readfile) != string(fexpected) || err != nil {
 		t.Error("Expect ReadFile integration test to pass")
+	}
+	readfileenvs, err := ReadFileSelectedEnvs("testdata/file-env.tmpl", []string{"BAR", "FOO", "BAZ", "ENV"})
+	if err != nil {
+		t.Error("ReadFileSelectedEnvs ran unsuccesfully")
+	}
+	fenvexpected, err := ioutil.ReadFile("testdata/file-env.out")
+	if string(readfileenvs) != string(fenvexpected) || err != nil {
+		t.Error("Expect ReadFileSelectedEnvs integration test to pass")
 	}
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -134,7 +134,7 @@ func TestParseStrictNoFailFast(t *testing.T) {
 
 func doTest(t *testing.T, m mode) {
 	for _, test := range parseTests {
-		result, err := New(test.name, FakeEnv, restrict[m]).Parse(test.input)
+		result, err := New(test.name, FakeEnv, restrict[m], []string{}).Parse(test.input)
 		hasErr := err != nil
 		if hasErr != test.hasErr[m] {
 			t.Errorf("%s=(error): got\n\t%v\nexpected\n\t%v\ninput: %s\nresult: %s\nerror: %v",
@@ -157,5 +157,22 @@ func doNegativeAssertTest(t *testing.T, m mode) {
 		if err.Error() != test.expected {
 			t.Errorf("%s=(%q): got\n\t%v\nexpected\n\t%v", test.name, test.input, err.Error(), test.expected)
 		}
+	}
+}
+
+func TestIsVarLookupable(t *testing.T) {
+	selectedEnvs := []string{"BAR"}
+	selectedEnvsEmpty := []string{}
+	if !isVarLookupable("BAR", selectedEnvs) {
+		t.Error("isVarLookupable failed to lookup BAR var")
+	}
+	if isVarLookupable("BAZ", selectedEnvs) {
+		t.Error("isVarLookupable failed to skip BAZ var")
+	}
+	if !isVarLookupable("FOO", selectedEnvsEmpty) {
+		t.Error("isVarLookupable failed to lookup FOO var")
+	}
+	if !isVarLookupable("ENV", selectedEnvsEmpty) {
+		t.Error("isVarLookupable failed to lookup ENV var")
 	}
 }

--- a/testdata/file-env.out
+++ b/testdata/file-env.out
@@ -1,0 +1,6 @@
+foo: bar
+baz: baz
+env: dev
+uri: http://bar.com/foo
+host: localhost
+macro: ${SYSTEMPATH}

--- a/testdata/file-env.tmpl
+++ b/testdata/file-env.tmpl
@@ -1,0 +1,6 @@
+foo: $BAR
+baz: ${FOO:=baz}
+env: ${ENV:-dev}
+uri: http://${BAR:=$BAZ}.com/foo
+host: ${BAR:+localhost}
+macro: ${SYSTEMPATH}


### PR DESCRIPTION
This PR intends to add a new feature for selecting which env vars the caller wants to lookup and replace while using the cli or programmatically.

I believe it addresses what was requested in https://github.com/a8m/envsubst/issues/25.

*Summary*

* A new `-envs` added for listing what env vars we want to lookup and replace.
  ```
  echo 'hi ${USER} at ${PWD}' |envsubst -envs ENV,USER
  > hi myuser at ${PWD}
  ```
* Add new funcs for selecting envs programmatically:
  * StringSelectedEnvs `envsubst.StringSelectedEnvs(input, []string{"ENV1"})`
  * StringRestrictedSelectedEnvs `envsubst.StringRestrictedSelectedEnvs(input, true, false, []string{"ENV1"})`
  * BytesSelectedEnvs `envsubst.BytesSelectedEnvs([]byte(input), []string{"ENV1"})`
  * BytesRestrictedSelectedEnvs `envsubst.BytesRestrictedSelectedEnvs([]byte(input), false, true, []string{"ENV1"})`
  * ReadFileSelectedEnvs `envsubst.ReadFileSelectedEnvs("filename", []string{"ENV1"})`
  * ReadFileRestrictedSelectedEnvs `envsubst.ReadFileRestrictedSelectedEnvs("filename", true, true, []string{"ENV1"})`
* Add more tests