### PR TITLE
Allow default value expression starting with operators

### DIFF
--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -1,8 +1,8 @@
 package parse
 
 import (
-	"testing"
 	"strings"
+	"testing"
 )
 
 type lexTest struct {
@@ -72,6 +72,28 @@ var lexTests = []lexTest{
 		{itemVariable, 0, "BAR"},
 		tColEquals,
 		{itemVariable, 0, "$BAZ"},
+		tRight,
+		{itemText, 0, " foo"},
+		tEOF,
+	}},
+	{"substitution-leading-dash-1", "bar ${BAR:--1} foo", []item{
+		{itemText, 0, "bar "},
+		tLeft,
+		{itemVariable, 0, "BAR"},
+		tColDash,
+		{itemText, 0, "-"},
+		{itemText, 0, "1"},
+		tRight,
+		{itemText, 0, " foo"},
+		tEOF,
+	}},
+	{"substitution-leading-dash-2", "bar ${BAR:=-1} foo", []item{
+		{itemText, 0, "bar "},
+		tLeft,
+		{itemVariable, 0, "BAR"},
+		tColEquals,
+		{itemText, 0, "-"},
+		{itemText, 0, "1"},
 		tRight,
 		{itemText, 0, " foo"},
 		tEOF,

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -63,6 +63,12 @@ var parseTests = []parseTest{
 	{"issue #1", "${hello:=wo_rld} ${foo:=bar_baz}", "wo_rld bar_baz", errNone},
 	{"issue #2", "name: ${NAME:=foo_qux}, key: ${EMPTY:=baz_bar}", "name: foo_qux, key: baz_bar", errNone},
 	{"gh-issue-8", "prop=${HOME_URL-http://localhost:8080}", "prop=http://localhost:8080", errNone},
+	// operators as leading values
+	{"gh-issue-41-1", "${NOTSET--1}", "-1", errNone},
+	{"gh-issue-41-2", "${NOTSET:--1}", "-1", errNone},
+	{"gh-issue-41-3", "${NOTSET=-1}", "-1", errNone},
+	{"gh-issue-41-4", "${NOTSET:==1}", "=1", errNone},
+
 	// bad substitution
 	{"closing brace expected", "hello ${", "", errAll},
 


### PR DESCRIPTION
Fixes #41

I hope that I got the lexing right and I think (according to the added test cases) that it actually fixes the issue without introducing new bugs. The trick was to only lex the any subsitition operator first and then continue with anything after the subsitution (such as constant text or another variable, which may in turn contain a substitution I suppose).