### PR TITLE
parse: proper single char variable detection

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -218,6 +218,8 @@ func lexSubstitutionOperator(l *lexer) stateFn {
 		return lexText
 	case r == eof || isEndOfLine(r):
 		return l.errorf("closing brace expected")
+	case isAlphaNumeric(r) && strings.HasPrefix(l.input[l.lastPos:], "${"):
+		return lexVariable
 	case r == '+':
 		l.emit(itemPlus)
 	case r == '-':

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -33,6 +33,12 @@ var lexTests = []lexTest{
 		{itemVariable, 0, "$hello"},
 		tEOF,
 	}},
+	{"single char var", "${A}", []item{
+		tLeft,
+		{itemVariable, 0, "A"},
+		tRight,
+		tEOF,
+	}},
 	{"2 vars", "$hello $world", []item{
 		{itemVariable, 0, "$hello"},
 		{itemText, 0, " "},

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -9,6 +9,7 @@ var FakeEnv = []string{
 	"FOO=foo",
 	"EMPTY=",
 	"ALSO_EMPTY=",
+	"A=AAA",
 }
 
 type mode int
@@ -68,6 +69,9 @@ var parseTests = []parseTest{
 	{"gh-issue-41-2", "${NOTSET:--1}", "-1", errNone},
 	{"gh-issue-41-3", "${NOTSET=-1}", "-1", errNone},
 	{"gh-issue-41-4", "${NOTSET:==1}", "=1", errNone},
+
+	// single letter
+	{"gh-issue-43-1", "${A}", "AAA", errNone},
 
 	// bad substitution
 	{"closing brace expected", "hello ${", "", errAll},


### PR DESCRIPTION
Fixes #43, regression from #42

@a8m Sorry for introducing that bug. If time permits for me, I may propose more refactorings to the lexer and its tests. Would you be willing to review/accept such changes?