### PR TITLE
Adding the availability to ignore some variables

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -40,6 +40,7 @@ const (
 	itemColonEquals // colon-equals (':=')
 	itemColonDash   // colon-dash(':-')
 	itemColonPlus   // colon-plus(':+')
+    itemIgnored     // double dollar ('$$') variable should be ignored
 	itemVariable    // variable starting with '$', such as '$hello' or '$1'
 	itemLeftDelim   // left action delimiter '${'
 	itemRightDelim  // right action delimiter '}'
@@ -194,6 +195,9 @@ func lexVariable(l *lexer) stateFn {
 	var r rune
 	for {
 		r = l.next()
+        if r == '$' {
+            l.emit(itemIgnored)
+        }
 		if !isAlphaNumeric(r) {
 			l.backup()
 			break

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -45,6 +45,15 @@ var lexTests = []lexTest{
 		{itemVariable, 0, "$world"},
 		tEOF,
 	}},
+	{"ignored var", "$$hello", []item{
+		{itemIgnored, 0, "$$hello"},
+		tEOF,
+	}},
+	{"2 ignored vars", "$$hello$$world", []item{
+		{itemIgnored, 0, "$$hello"},
+        {itemIgnored, 0, "$$world"},
+		tEOF,
+	}},
 	{"substitution-1", "bar ${BAR}", []item{
 		{itemText, 0, "bar "},
 		tLeft,

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -117,6 +117,9 @@ Loop:
 				continue
 			}
 			fallthrough
+        case itemIgnored:
+            textNode := NewText(strings.TrimPrefix(t.val, "$"))
+			p.nodes = append(p.nodes, textNode)
 		default:
 			textNode := NewText(t.val)
 			p.nodes = append(p.nodes, textNode)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -47,6 +47,8 @@ var parseTests = []parseTest{
 	{"with text", "$BAR baz", "bar baz", errNone},
 	{"concatenated", "$BAR$FOO", "barfoo", errNone},
 	{"2 env var", "$BAR - $FOO", "bar - foo", errNone},
+	{"ignored var", "$$BAR - $$FOO", "$BAR - $FOO", errNone},
+	{"2 ignored vars", "$BAR - $FOO", "$BAR - $FOO", errNone},
 	{"invalid var", "$_ bar", "$_ bar", errNone},
 	{"invalid subst var", "${_} bar", "${_} bar", errNone},
 	{"value of $var", "${BAR}baz", "barbaz", errNone},


### PR DESCRIPTION
I added the availability to ignore some variables by using two dollar signs followed by the text that shouldn't be edited `$$FOO` => `$FOO`. And only consider it as text