### PR TITLE
ci: Version bump for `test.yml` GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.20', '1.21' ]
 
     name: Go ${{ matrix.go }} testing
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
- [`actions/checkout`](https://github.com/actions/checkout) has had v3 out for a while, currently v3.6.
- `actions/setup-go` has had two major releases since ([v3](https://github.com/actions/setup-go/releases/tag/v3.0.0) and [v4](https://github.com/actions/setup-go/releases/tag/v4.0.0)).

Doesn't look like there is any breaking changes across those major version releases that would affect the simple workflow config, it should be ok to version bump?

I'm not familiar with why a matrix with two versions of Go is used. I've bumped those to the two latest Go releases.