### PR TITLE
ci: Version bump for workflow `binaries.yml`

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -9,8 +9,8 @@ jobs:
     name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
@@ -22,8 +22,8 @@ jobs:
     name: release linux/arm64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
@@ -35,8 +35,8 @@ jobs:
     name: release darwin/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
@@ -48,8 +48,8 @@ jobs:
     name: release darwin/arm64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
@@ -61,8 +61,8 @@ jobs:
     name: release windows
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: windows


### PR DESCRIPTION
- [`actions/checkout`](https://github.com/actions/checkout) has had v3 out for a while, currently `v3.6`.
- [`wangyoucao5777/go-release-action`](https://github.com/wangyoucao577/go-release-action) bumped to `v1.4`

Doesn't look like there is any breaking changes across those major version releases that would affect the simple workflow config, it should be ok to version bump?

Possibly a mistake in `go-release-action` 1.4 if [this change](https://github.com/wangyoucao577/go-release-action/pull/133) results in `armv64` (_they intended to treat `arm8` => `armv8`, but this would be wrong for `arm64`_ 🤷‍♂️ ). Shouldn't be an issue here as the action in the workflow is configured with an explicit filename instead (`asset_name`).