### PR TITLE
Update Go v1.24

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,13 +4,17 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release-linux-amd64:
     name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
@@ -23,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
@@ -36,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
@@ -49,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
@@ -62,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.23', '1.24' ]
 
     name: Go ${{ matrix.go }} testing
     steps:

--- a/_example/main.go
+++ b/_example/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/a8m/envsubst"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.21
-
-require gopkg.in/yaml.v2 v2.4.0 // indirect
+go 1.24

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,0 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Hello maintainers,

We have used `envsubst` in one project docker image built. However, once image gets scanned on Docker hub, it shows lots of CVEs due to the old Go version.
I tried to upgrade to the latest Go version as of now v1.24, could see CI test get passed.
I also updated the workflow with deps version latest to deploy the binaries. It also get passed in my fork.
So, it is cool if you consider this PR and release a new version in main stream.
Fixes https://github.com/a8m/envsubst/issues/62

![image](https://github.com/user-attachments/assets/abe4fcd8-1a91-4dae-b642-a016ab4ea9e3)

Here is the result after upgrading. There is no Go CVE 

![image](https://github.com/user-attachments/assets/4301bf40-8312-4f2e-a137-8adf6acc9fca)
