### PR TITLE
Bump Go v1.24.4 to fix CVEs

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,7 @@ name: Release Binaries
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,7 +4,18 @@ on:
   release:
     types: [ created ]
   workflow_dispatch:
-
+    inputs:
+      tag_name:
+        description: 'Tag name to build from (e.g., v1.4.5)'
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Tag name to build from'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag_name || github.ref_name }}
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag_name || github.ref_name }}
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag_name || github.ref_name }}
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,6 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag_name || github.ref_name }}
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,6 +87,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag_name || github.ref_name }}
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,9 @@ name: Release Binaries
 
 on:
   release:
-    types: [published]
+    types: [ created ]
+  workflow_dispatch:
+
 
 permissions:
   contents: write

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,20 +2,16 @@ name: Release Binaries
 
 on:
   release:
-    types: [ created ]
+    types:
+    - created
+    - published
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name to build from (e.g., v1.4.5)'
+        description: 'Release tag name (e.g., v1.4.5). Can ignore this if selecting workflow run from a release tag.'
         required: false
         type: string
         default: ''
-  workflow_call:
-    inputs:
-      tag_name:
-        description: 'Tag name to build from'
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -37,6 +33,7 @@ jobs:
         project_path: cmd/envsubst
         asset_name: envsubst-Linux-x86_64
         compress_assets: OFF
+        release_name: ${{ inputs.tag_name || '' }}
   release-linux-arm64:
     name: release linux/arm64
     runs-on: ubuntu-latest
@@ -52,6 +49,7 @@ jobs:
         project_path: cmd/envsubst
         asset_name: envsubst-Linux-arm64
         compress_assets: OFF
+        release_name: ${{ inputs.tag_name || '' }}
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
@@ -67,6 +65,7 @@ jobs:
         project_path: cmd/envsubst
         asset_name: envsubst-Darwin-x86_64
         compress_assets: OFF
+        release_name: ${{ inputs.tag_name || '' }}
   release-darwin-arm64:
     name: release darwin/arm64
     runs-on: ubuntu-latest
@@ -82,6 +81,7 @@ jobs:
         project_path: cmd/envsubst
         asset_name: envsubst-Darwin-arm64
         compress_assets: OFF
+        release_name: ${{ inputs.tag_name || '' }}
   release-windows:
     name: release windows
     runs-on: ubuntu-latest
@@ -98,3 +98,4 @@ jobs:
         binary_name: envsubst-windows #release fails if the binary name is the same as the asset name
         asset_name: envsubst
         compress_assets: OFF
+        release_name: ${{ inputs.tag_name || '' }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,28 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Release name. Example: v1.0.0'
+        required: true
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Create tag
+      run: |
+        git tag ${{ github.event.inputs.release_name }}
+        git push -f origin ${{ github.event.inputs.release_name }}
+    - name: Create GitHub release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.event.inputs.release_name }}
+        release_name: ${{ github.event.inputs.release_name }}
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,7 +52,16 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Call binaries workflow
-      uses: ./.github/workflows/binaries.yml
+    - name: Release binaries
+      uses: actions/github-script@v7
       with:
-        tag_name: ${{ inputs.tag_name }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'binaries.yml',
+            ref: '${{ inputs.tag_name }}',
+            inputs: {
+              tag_name: '${{ inputs.tag_name }}'
+            }
+          });

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,26 +3,63 @@ name: Create Release
 on:
   workflow_dispatch:
     inputs:
-      release_name:
-        description: 'Release name. Example: v1.0.0'
+      tag_name:
+        description: 'Release tag name (e.g., v1.4.5)'
         required: true
+        type: string
+      release_title:
+        description: 'Release title (optional)'
+        required: false
+        type: string
+        default: ''
+      release_body:
+        description: 'Release description (optional)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create tag
       run: |
-        git tag ${{ github.event.inputs.release_name }}
-        git push -f origin ${{ github.event.inputs.release_name }}
-    - name: Create GitHub release
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git tag -a "${{ inputs.tag_name }}" -m "Release ${{ inputs.tag_name }}"
+        git push origin "${{ inputs.tag_name }}"
+
+    - name: Create Release
+      id: create_release
       uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.event.inputs.release_name }}
-        release_name: ${{ github.event.inputs.release_name }}
+        tag_name: ${{ inputs.tag_name }}
+        release_name: ${{ inputs.release_title || inputs.tag_name }}
+        body: ${{ inputs.release_body }}
         draft: false
         prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Trigger binaries workflow
+      run: |
+        # Wait a moment for the release to be fully created
+        sleep 10
+
+        # Trigger the binaries workflow
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/dispatches \
+          -d '{"ref":"main"}' 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -58,17 +58,3 @@ jobs:
         draft: false
         prerelease: false
       continue-on-error: true
-
-    - name: Release binaries
-      uses: actions/github-script@v7
-      with:
-        script: |
-          await github.rest.actions.createWorkflowDispatch({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: 'binaries.yml',
-            ref: '${{ inputs.tag_name }}',
-            inputs: {
-              tag_name: '${{ inputs.tag_name }}'
-            }
-          });

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,8 +37,14 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git tag -a "${{ inputs.tag_name }}" -m "Release ${{ inputs.tag_name }}"
-        git push origin "${{ inputs.tag_name }}"
+
+        # Check if tag already exists
+        if git rev-parse "${{ inputs.tag_name }}" >/dev/null 2>&1; then
+          echo "Tag ${{ inputs.tag_name }} already exists, skipping tag creation"
+        else
+          git tag -a "${{ inputs.tag_name }}" -m "Release ${{ inputs.tag_name }}"
+          git push origin "${{ inputs.tag_name }}"
+        fi
 
     - name: Create Release
       id: create_release
@@ -51,6 +57,7 @@ jobs:
         body: ${{ inputs.release_body }}
         draft: false
         prerelease: false
+      continue-on-error: true
 
     - name: Release binaries
       uses: actions/github-script@v7

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,14 +52,7 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Trigger binaries workflow
-      run: |
-        # Wait a moment for the release to be fully created
-        sleep 10
-
-        # Trigger the binaries workflow
-        curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/dispatches \
-          -d '{"ref":"main"}' 
+    - name: Call binaries workflow
+      uses: ./.github/workflows/binaries.yml
+      with:
+        tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23', '1.24' ]
+        go: [ '1.24', '1.25' ]
 
     name: Go ${{ matrix.go }} testing
     steps:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,70 @@ func main() {
 
 * `os.ExpandEnv(s string) string` - only supports `$var` and `${var}` notations
 
+#### Creating Releases
+
+This project uses automated workflows to create releases with prebuilt binaries for multiple platforms.
+
+##### Release Workflows
+
+**`create-release.yml`**: Creates git tags and GitHub releases
+- **Trigger**: Manual via GitHub Actions UI
+- **Inputs**: Tag name, optional release title and description
+- **Features**: 
+  - Creates git tag (skips if already exists)
+  - Creates GitHub release
+  - Handles existing tags gracefully (rerunnable)
+
+**`binaries.yml`**: Builds and uploads binaries
+- **Triggers**: 
+  - Automatically on release creation
+  - Manual dispatch with optional tag name
+- **Platforms**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+- **Features**: Builds from specific tag or latest release
+
+##### Release Procedure
+
+1. Go to the **Actions** tab in the GitHub repository
+2. Select the **"Create Release"** workflow
+3. Click **"Run workflow"**
+4. Enter the tag name following semantic versioning (e.g., `v1.4.5`)
+5. Optionally provide a release title and description
+6. Click **"Run workflow"**
+7. Wait for the workflow to complete successfully
+8. Go back to the **Actions** tab and select the **"Release Binaries"** workflow
+9. Click **"Run workflow"** to build and upload binaries for the new release
+10. Enter the same tag name in step (4) (or select `Use workflow from` released tag)
+11. Click **"Run workflow"**
+
+##### What Happens During Release
+
+1. **Tag Creation**: Creates a git tag with the specified version
+2. **Release Creation**: Creates a GitHub release with optional title/description
+3. **Binary Building**: Automatically triggers binary builds for all platforms:
+   - `envsubst-Linux-x86_64` (Linux AMD64)
+   - `envsubst-Linux-arm64` (Linux ARM64)
+   - `envsubst-Darwin-x86_64` (macOS Intel)
+   - `envsubst-Darwin-arm64` (macOS Apple Silicon)
+   - `envsubst` (Windows AMD64)
+4. **Asset Upload**: Binaries are automatically attached to the release
+
+##### Rerunning Releases
+
+- **Same Tag**: Both workflows can be rerun with the same tag name
+- **Tag Exists**: The create-release workflow will skip tag creation if it already exists
+- **Release Exists**: The workflow continues even if the release already exists
+- **Binary Rebuild**: Use the binaries workflow to rebuild assets for existing releases
+
+##### Supported Platforms
+
+| Platform | Architecture  | Binary Name              |
+|----------|---------------|--------------------------|
+| Linux    | AMD64         | `envsubst-Linux-x86_64`  |
+| Linux    | ARM64         | `envsubst-Linux-arm64`   |
+| macOS    | Intel         | `envsubst-Darwin-x86_64` |
+| macOS    | Apple Silicon | `envsubst-Darwin-arm64`  |
+| Windows  | AMD64         | `envsubst`               |
+
 #### License
 MIT
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.24.7
+go 1.25.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.24
+go 1.24.2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.25.3
+go 1.25.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.24.2
+go 1.24.4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.24.4
+go 1.24.7


### PR DESCRIPTION
- Bumped up Go to v1.24.4 for https://github.com/advisories/GHSA-62jj-gr2r-5c34 , https://github.com/advisories/GHSA-jw54-c8rr-pjpq and https://github.com/advisories/GHSA-6f52-wpx2-hvf2
- Add workflow to create tag and release (instead of doing that from local and push)
<img width="216" alt="image" src="https://github.com/user-attachments/assets/d5b8209d-e372-40e0-8ec5-87c4a1e523c3" />

Checkout result: https://github.com/NDViet/envsubst/actions/runs/16096050069

- Workflow release binaries can be triggered by giving a release tag.
<img width="233" alt="image" src="https://github.com/user-attachments/assets/adc61dc6-b48e-4755-8085-55c94f2bb2b4" />

Checkout result: https://github.com/NDViet/envsubst/actions/runs/16096060363